### PR TITLE
fix(ci): include necessary secret env vars in Test Before Merge workflow

### DIFF
--- a/.github/workflows/test_merge.yml
+++ b/.github/workflows/test_merge.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      EDGE_STORE_ACCESS_KEY: ${{ secrets.EDGE_STORE_ACCESS_KEY }}
+      EDGE_STORE_SECRET_KEY: ${{ secrets.EDGE_STORE_SECRET_KEY }}
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This PR ensures that the `Test Before Merge` GitHub Actions workflow has access to required secrets for successful builds. Changes include:

- Added `EDGE_STORE_ACCESS_KEY` and `EDGE_STORE_SECRET_KEY` environment variables from GitHub Secrets.
- Added `CLERK_SECRET_KEY` environment variable from GitHub Secrets.

These updates resolve the EdgeStoreCredentialsError and allow `npm run build` to complete during CI.